### PR TITLE
Cap count of headers, extensions, ciphers

### DIFF
--- a/armor/src/main/java/org/owasp/netryx/fingerprint/request/Ja4hFingerprint.java
+++ b/armor/src/main/java/org/owasp/netryx/fingerprint/request/Ja4hFingerprint.java
@@ -40,8 +40,11 @@ public class Ja4hFingerprint {
         var methodPrefix = httpMethod.substring(0, 2).toLowerCase();
         var cookiePresence = hasCookie ? "c" : "n";
         var refererPresence = hasReferer ? "r" : "n";
+        // Adjust header count as defined in the specification, max value is always 99:
+        // https://github.com/FoxIO-LLC/ja4/blob/53ad7eaf1abce2a653eebb1b4a4196f08be7f94d/technical_details/JA4H.md?plain=1#L7
+        var adjustedHeaderCount = Math.min(99, headerCount);
 
-        return String.format("%s%s%s%s%d%s", methodPrefix, httpVersion, cookiePresence, refererPresence, headerCount, acceptLanguage);
+        return String.format("%s%s%s%s%02d%s", methodPrefix, httpVersion, cookiePresence, refererPresence, adjustedHeaderCount, acceptLanguage);
     }
 
     private String generateJa4hb() {

--- a/armor/src/main/java/org/owasp/netryx/fingerprint/tls/Ja4Fingerprint.java
+++ b/armor/src/main/java/org/owasp/netryx/fingerprint/tls/Ja4Fingerprint.java
@@ -98,11 +98,13 @@ public class Ja4Fingerprint implements TlsFingerprint {
     private String generateJa4a() {
         var tlsVersion = getTlsVersion();
         var sni = hello.getExtensions().getExtension(ExtensionType.SERVER_NAME, ServerName.class);
-        var ciphersCount = getCipherSuites().size();
-        var extensionsCount = getExtensions().size();
+        // Cap both cipher and extension count at 99 as per the specification:
+        // https://github.com/FoxIO-LLC/ja4/blob/53ad7eaf1abce2a653eebb1b4a4196f08be7f94d/technical_details/JA4.md?plain=1#L55
+        var ciphersCount = Math.min(99, getCipherSuites().size());
+        var extensionsCount = Math.min(99, getExtensions().size());
         var alpnProtocol = getFirstAlpnProtocol();
 
-        return String.format("%s%s%s%d%d%s",
+        return String.format("%s%s%s%02d%02d%s",
                 transportProtocol.name().toLowerCase().charAt(0),
                 tlsVersion,
                 (sni == null ? "i" : "d"),


### PR DESCRIPTION
While trying to implement JA4H I stumbled over the question of how headers should be counted: https://github.com/FoxIO-LLC/ja4/issues/172
Turns out, it should always be two digits, capped at 99. Same is true for extensions and ciphers. I checked some implementations of JA4/JA4H and saw that netryx wasn't doing that yet.